### PR TITLE
js guidelines: fix block statement rules suggestions

### DIFF
--- a/JavaScript/.eslintrc.js
+++ b/JavaScript/.eslintrc.js
@@ -15,6 +15,8 @@ module.exports = {
             'ignoreTrailingComments': false,
             'ignoreComments': false
         }],
+        'curly': ['error', 'all'],
+        'brace-style': ['error', '1tbs', { 'allowSingleLine': false }],
         indent: ['error', 4, {
             SwitchCase: 1,
         }],

--- a/JavaScript/Javascript.md
+++ b/JavaScript/Javascript.md
@@ -1602,7 +1602,7 @@ Heavily inspired by and partly composed of [Airbnb JavaScript Style Guide
 ## Blocks
 
 <a name="blocks--braces"></a>
-- [15.1](#blocks--braces) Use braces with if statements, and break up block statments into multiple lines. eslint: [`curly`](https://eslint.org/docs/latest/rules/curly) [`brace-style`](https://eslint.org/docs/latest/rules/brace-style)
+- [15.1](#blocks--braces) Use block statements within control structures, and break up block statements into multiple lines. eslint: [`curly`](https://eslint.org/docs/latest/rules/curly) [`brace-style`](https://eslint.org/docs/latest/rules/brace-style)
 
   ```javascript
   // bad

--- a/JavaScript/Javascript.md
+++ b/JavaScript/Javascript.md
@@ -1602,7 +1602,7 @@ Heavily inspired by and partly composed of [Airbnb JavaScript Style Guide
 ## Blocks
 
 <a name="blocks--braces"></a>
-- [15.1](#blocks--braces) Use braces with all multiline blocks. eslint: [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position)
+- [15.1](#blocks--braces) Use braces with if statements, and break up block statments into multiple lines. eslint: [`curly`](https://eslint.org/docs/latest/rules/curly) [`brace-style`](https://eslint.org/docs/latest/rules/brace-style)
 
   ```javascript
   // bad


### PR DESCRIPTION
nonblock-statement-body-position doesn't do what is described in the text and in the example. curly + brace-style do the intended job